### PR TITLE
fix: add missing selection css

### DIFF
--- a/src/css/general.css
+++ b/src/css/general.css
@@ -22,7 +22,7 @@ button:hover{
         cursor: var(--saturn_liprod), auto;
 }
 
-textarea:hover{
+textarea:hover, input[type="text"]:hover{
         cursor: var(--sailor-pencil), auto;
 }
 


### PR DESCRIPTION
I forget to add input type of text for pencil cursor selection, fixed it.